### PR TITLE
Modified defining app's "after" method to defining singleton method

### DIFF
--- a/lib/rspec/padrino/matchers/routing_matchers.rb
+++ b/lib/rspec/padrino/matchers/routing_matchers.rb
@@ -9,7 +9,7 @@ module RSpec::Padrino::Matchers
     @_routing_matchers_hook = lambda do
       apps = Padrino.mounted_apps.map(&:app_obj)
       apps.each do |the_app|
-        the_app.class_eval do
+        the_app.instance_eval do
           after do
             last_params = params
             last_name = request.route_obj && request.route_obj.named


### PR DESCRIPTION
RSpec::Padrino をincludeしないテストでも、一度、include RSpec::Padrino した後のテストがすべて遅くなってしまう現象が発生しました。

とりあえず、after を class_eval でなく instance_eval にして、他のテストに影響だろう変更にしてみました。

Sorry writing in japanese.
