### PR TITLE
Fix link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then edit `spec_helper.rb` like:
       Padrino.application
     end
 
-more usage on RDoc: <http://rubydoc.info/github/udzura/rspec-padrino/v0.2.0/frames>
+more usage on RDoc: <http://rubydoc.info/github/udzura/rspec-padrino/frames>
 
 ## Related Sites
 


### PR DESCRIPTION
The README link does not point to the docs properly, so I changed it since it works without the version number.  Or maybe you just need to regenerate RDoc's for that version?  At any rate, here's a fix if you're interested.  Thanks.
