### PR TITLE
Don't build an absolute URI if head argument is an instance of String and started with schema

### DIFF
--- a/lib/rspec/padrino/matchers/redirect_to.rb
+++ b/lib/rspec/padrino/matchers/redirect_to.rb
@@ -1,12 +1,22 @@
 module RSpec::Padrino::Matchers
   module RedirectTo
     extend RSpec::Matchers::DSL
+    SCHEMA_REGEXP = /\A[A-z][A-z0-9\+\.\-]*:/.freeze
 
     matcher :redirect_to do |*expected|
       match do |response|
-        @expected_url = last_application.absolute_url(*expected)
+        @expected_url = make_expected_url(*expected)
         @actual_url = response.location
         response.redirect? && @expected_url == @actual_url
+      end
+
+      def make_expected_url(*args)
+        head = args.first
+        if args.length == 1 && head.kind_of?(String) && head =~ SCHEMA_REGEXP
+          args.shift
+        else
+          last_application.absolute_url(*expected)
+        end
       end
 
       failure_message_for_should do |actual|

--- a/spec/integrations/matchers_spec.rb
+++ b/spec/integrations/matchers_spec.rb
@@ -82,6 +82,11 @@ describe "Integrations" do
         get "/baz/captures/123"
         should_not redirect_to(:baz, :captures, :id => 123)
       end
+
+      it "should not fail even if only one argument is an instance of non-string" do
+        get "/cushion", q: "/one"
+        should redirect_to(:one)
+      end
     end
 
     context "with URI" do
@@ -98,6 +103,18 @@ describe "Integrations" do
       it "should fail if does not redirect" do
         get "/baz/captures/123"
         should_not redirect_to("/baz/captures/123")
+      end
+    end
+
+    context "with absolute URI" do
+      it "redirects to http://example.com" do
+        get "/cushion", :q => "http://example.com"
+        should redirect_to("http://example.com")
+      end
+
+      it "redirects to ftp://example.com" do
+        get "/cushion", :q => "ftp://example.com"
+        should redirect_to("ftp://example.com")
       end
     end
   end

--- a/spec/integrations/mock_app_helper.rb
+++ b/spec/integrations/mock_app_helper.rb
@@ -54,6 +54,12 @@ class TestApp < Padrino::Application
     end
   end
 
+  get(:one){}
+
+  get :cushion do
+    redirect params[:q]
+  end
+
   helpers do
     def foo_index_path
       url_for(:foo, :index)


### PR DESCRIPTION
Sorry for my bad.
Currently the `redirect_to` matcher doesn't support absolute URI.

Also, `SCHEMA_REGEXP` is same with Sinatra Helpers's implementation.