### PR TITLE
Fix. Bundler could not find compatible versions for gem padrino-core

### DIFF
--- a/rspec-padrino.gemspec
+++ b/rspec-padrino.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sinatra", ">= 0"
-  spec.add_runtime_dependency "padrino-core", "~> 0.13.0.beta1"
+  spec.add_runtime_dependency "padrino-core", "~> 0.13.0"
   spec.add_runtime_dependency "rspec", ">= 2.0"
   spec.add_runtime_dependency "rack-test", ">= 0"
 
-  spec.add_development_dependency "padrino-helpers", "~> 0.13.0.beta1"
+  spec.add_development_dependency "padrino-helpers", "~> 0.13.0"
   spec.add_development_dependency "rdoc", ">= 0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "simplecov", ">= 0"


### PR DESCRIPTION
I want to use padrino v0.13.1 and rspec-padrino v0.2.1, but I can not install for version conflict. 

```sh
$ bundle update rspec-padrino
Fetching gem metadata from https://rubygems.org/............
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies.....
Bundler could not find compatible versions for gem "padrino-core":
  In Gemfile:
    padrino (= 0.13.1) was resolved to 0.13.1, which depends on
      padrino-core (= 0.13.1)

    padrino (= 0.13.1) was resolved to 0.13.1, which depends on
      padrino-core (= 0.13.1)

    padrino (= 0.13.1) was resolved to 0.13.1, which depends on
      padrino-core (= 0.13.1)

    padrino (= 0.13.1) was resolved to 0.13.1, which depends on
      padrino-core (= 0.13.1)

    padrino (= 0.13.1) was resolved to 0.13.1, which depends on
      padrino-core (= 0.13.1)

    rspec-padrino (= 0.2.1) was resolved to 0.2.1, which depends on
      padrino-core (~> 0.12.0)
```

So I relaxed dependency. `bundle update` was successful.
