### PR TITLE
Relax padrino-core dependency for padrino v0.14

### DIFF
--- a/rspec-padrino.gemspec
+++ b/rspec-padrino.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sinatra", ">= 0"
-  spec.add_runtime_dependency "padrino-core", "~> 0.13.0"
+  spec.add_runtime_dependency "padrino-core", ">= 0.13.0"
   spec.add_runtime_dependency "rspec", ">= 2.0"
   spec.add_runtime_dependency "rack-test", ">= 0"
 
-  spec.add_development_dependency "padrino-helpers", "~> 0.13.0"
+  spec.add_development_dependency "padrino-helpers", ">= 0.13.0"
   spec.add_development_dependency "rdoc", ">= 0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "simplecov", ">= 0"


### PR DESCRIPTION
latest `padrino` is v0.14.0.1, but `rspec-padrino` is locking with v0.13.x
So I relaxed dependency

It seems no problem at my environment. (padrino v0.14.0.1)